### PR TITLE
Light casters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Executables
 set(CHAPTER "2.lighting") # NOTE: update this depending on the chapter being built!
-set(SUBCHAPTER "15.lighting_maps")
+set(SUBCHAPTER "16.light_casters")
 add_executable(${PROJECT_NAME} src/${CHAPTER}/${SUBCHAPTER}/main.cpp src/glad.c src/stb_image.c)
 
 # Libraries

--- a/src/2.lighting/16.light_casters/lamp.frag
+++ b/src/2.lighting/16.light_casters/lamp.frag
@@ -1,0 +1,9 @@
+#version 330 core
+out vec4 FragColor;
+
+uniform vec3 lightColor;
+
+void main()
+{
+    FragColor = vec4(lightColor, 1.0f);
+}

--- a/src/2.lighting/16.light_casters/lamp.vert
+++ b/src/2.lighting/16.light_casters/lamp.vert
@@ -1,0 +1,11 @@
+#version 330 core
+layout(location = 0) in vec3 aPos;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main() 
+{
+    gl_Position = projection * view * model * vec4(aPos, 1.0f); 
+}

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -227,30 +227,17 @@ while (!glfwWindowShouldClose(window)) {
     // use object shader
     objectShader.use();
 
-    // set directional lighting properties (our sun)
-    objectShader.setVec3("sun.direction", -20.0f, -10.0f, -30.0f);
-    objectShader.setVec3("sun.ambient",     0.2f, 0.2f, 0.2f);
-    objectShader.setVec3("sun.diffuse",     0.5f, 0.5f, 0.5f);
-    objectShader.setVec3("sun.specular",    1.0f, 1.0f, 1.0f);
-
-    // set point lighting properties
-    objectShader.setVec3("lamp.position", -0.2f, -0.1f, -0.3f);
-    objectShader.setVec3("lamp.ambient",   0.2f, 0.2f, 0.2f);
-    objectShader.setVec3("lamp.diffuse",   0.5f, 0.5f, 0.5f);
-    objectShader.setVec3("lamp.specular",  1.0f, 1.0f, 1.0f);
-
-    objectShader.setFloat("lamp.constant",  1.0f);
-    objectShader.setFloat("lamp.linear",    0.09f);
-    objectShader.setFloat("lamp.quadratic", 0.032f);
-
     // set flashlight properties
-    objectShader.setVec3("torch.position", camera->cameraPos);
-    objectShader.setVec3("torch.direction", camera->cameraFront);
-    objectShader.setFloat("torch.cutOff", glm::cos(glm::radians(18.0f)));
-    objectShader.setFloat("torch.outerCutOff", glm::cos(glm::radians(19.0f)));
-    objectShader.setVec3("torch.ambient",  glm::vec3(0.2));
-    objectShader.setVec3("torch.diffuse",  glm::vec3(0.5));
-    objectShader.setVec3("torch.specular", glm::vec3(1.0));
+    objectShader.setVec3(  "light.position",    camera->cameraPos);
+    objectShader.setVec3(  "light.direction",   camera->cameraFront);
+    objectShader.setFloat( "light.cutOff",      glm::cos(glm::radians(18.0f)));
+    objectShader.setFloat( "light.outerCutOff", glm::cos(glm::radians(19.0f)));
+    objectShader.setVec3(  "light.ambient",     glm::vec3(0.2));
+    objectShader.setVec3(  "light.diffuse",     glm::vec3(0.7));
+    objectShader.setVec3(  "light.specular",    glm::vec3(1.0));
+    objectShader.setFloat( "light.constant",    1.0f);
+    objectShader.setFloat( "light.linear",      0.09f);
+    objectShader.setFloat( "light.quadratic",   0.032f);
 
     // set object material properties
     objectShader.setInt("material.diffuse", 0);
@@ -259,7 +246,6 @@ while (!glfwWindowShouldClose(window)) {
 
     // set object position
     objectShader.setVec3("viewPos", camera->cameraPos);
-    //objectShader.setMat4("model", model);
     objectShader.setMat4("view", view);
     objectShader.setMat4("projection", projection);
 

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -227,11 +227,22 @@ while (!glfwWindowShouldClose(window)) {
     // use object shader
     objectShader.use();
 
-    // set object lighting properties
-    objectShader.setVec3("light.direction", -0.2f, -0.1f, -0.3f);
-    objectShader.setVec3("light.ambient", 0.2f, 0.2f, 0.2f);
-    objectShader.setVec3("light.diffuse", 0.5f, 0.5f, 0.5f);
-    objectShader.setVec3("light.specular", 1.0f, 1.0f, 1.0f);
+    // set directional lighting properties (our sun)
+    objectShader.setVec3("sun.direction", -20.0f, -10.0f, -30.0f);
+    objectShader.setVec3("sun.ambient",     0.2f, 0.2f, 0.2f);
+    objectShader.setVec3("sun.diffuse",     0.5f, 0.5f, 0.5f);
+    objectShader.setVec3("sun.specular",    1.0f, 1.0f, 1.0f);
+
+    // set point lighting properties
+    objectShader.setVec3("torch.position", -0.2f, -0.1f, -0.3f);
+    objectShader.setVec3("torch.ambient",   0.2f, 0.2f, 0.2f);
+    objectShader.setVec3("torch.diffuse",   0.5f, 0.5f, 0.5f);
+    objectShader.setVec3("torch.specular",  1.0f, 1.0f, 1.0f);
+
+    objectShader.setFloat("torch.constant",  1.0f);
+    objectShader.setFloat("torch.linear",    0.09f);
+    objectShader.setFloat("torch.quadratic", 0.032f);
+
 
     // set object material properties
     objectShader.setInt("material.diffuse", 0);
@@ -240,7 +251,7 @@ while (!glfwWindowShouldClose(window)) {
 
     // set object position
     objectShader.setVec3("viewPos", camera->cameraPos);
-    objectShader.setMat4("model", model);
+    //objectShader.setMat4("model", model);
     objectShader.setMat4("view", view);
     objectShader.setMat4("projection", projection);
 

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -19,6 +19,18 @@ void mouse_callback(GLFWwindow* window, double xpos, double ypos); // xpos and y
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 float genRandFloat(float min, float max);
 unsigned int loadTexture(std::string texPath);
+void setPointLights(int MAX_POINT_LIGHTS);
+
+// structs
+typedef struct PointLightSetting {
+    glm::vec3 pos;
+    glm::vec3 ambient;
+    glm::vec3 diffuse;
+    glm::vec3 specular;
+    float constant;
+    float linear;
+    float quadratic;
+} PointLightSetting;
 
 // settings
 const unsigned int SCR_WIDTH    = 1200;
@@ -256,6 +268,7 @@ while (!glfwWindowShouldClose(window)) {
     //}
 
     // TODO: Condense this monstrosity please for the love of god
+/*
     objectShader.setVec3  ("pointLights[0].position" ,     pointLightPos[0] );
     objectShader.setVec3  ("pointLights[0].ambient"  ,     glm::vec3(0.2) );
     objectShader.setVec3  ("pointLights[0].diffuse"  ,     glm::vec3(0.5) );
@@ -287,6 +300,10 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setFloat ("pointLights[3].constant" ,     1.0      );
     objectShader.setFloat ("pointLights[3].linear"   ,     0.09     );
     objectShader.setFloat ("pointLights[3].quadratic",     0.032    );
+*/
+    
+
+
 
     // set object material properties
     objectShader.setInt("material.diffuse", 0);
@@ -449,7 +466,7 @@ float genRandFloat(float min, float max) {
 }
 
 // TODO: write a function to set the options for pointlight(s) shader
-void setPointLights(int MAX_POINT_LIGHTS) {
+void setPointLights(const int MAX_POINT_LIGHTS, const PointLightSetting& pls, const Shader& shaderProgram) { // pls uwu 🥺👉👈
     const std::vector<std::string> settings = {
         "position",
         "ambient",
@@ -460,8 +477,8 @@ void setPointLights(int MAX_POINT_LIGHTS) {
         "quadratic"
     };
 
-    const int sz = (std::string("pointLights[n]")).size();
-    char plStr[sz];
+    const int sz = (std::string("pointLights[n]")).size() + 1; // golly i love strings
+    char plChArr[sz];
 
     // NOTE: this is super restrictive, but i can't imagine myself adding more than 10 point lights for the
     //  scope of this project anyways
@@ -471,12 +488,16 @@ void setPointLights(int MAX_POINT_LIGHTS) {
     }
 
     for (int idx = 0; idx < MAX_POINT_LIGHTS; ++idx) {
-        snprintf(plStr, sz, "pointLights[%d]", idx);
+        snprintf(plChArr, sz, "pointLights[%d]", idx);
+        std::string plStr(plChArr);
 
-        // ... 
-
-
-
-
+        shaderProgram.setVec3 (plStr, pls.pos);
+        shaderProgram.setVec3 (plStr, pls.ambient);
+        shaderProgram.setVec3 (plStr, pls.diffuse);
+        shaderProgram.setVec3 (plStr, pls.specular);
+        shaderProgram.setFloat(plStr, pls.constant);
+        shaderProgram.setFloat(plStr, pls.linear);
+        shaderProgram.setFloat(plStr, pls.quadratic);
+        }
     }
 }

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -35,7 +35,7 @@ typedef struct Phong {
 } Phong;
 
 typedef struct PointLightSetting {
-    glm::vec3   pos;
+    glm::vec3   position;
     Phong       phong;
     Attenuation attenuation;
 } PointLightSetting;
@@ -188,6 +188,26 @@ for (int pointLightIdx = 0; pointLightIdx < NR_POINT_LIGHTS; ++pointLightIdx) {
     pointLightPos.push_back(newPos);
 }
 
+// generate multiple point light settings
+Attenuation att = { 1.0f, 0.09f, 0.032f };
+Phong phong = { glm::vec3(0.2f), glm::vec3(0.5f), glm::vec3(1.0f), };
+
+std::vector<PointLightSetting> settings;
+settings.reserve(NR_POINT_LIGHTS);
+
+for (int idx = 0; idx < NR_POINT_LIGHTS; ++idx) {
+    int x, y, z;
+    x = genRandFloat(-3, 3);
+    y = genRandFloat(-3, 3);
+    z = genRandFloat(-3, 3);
+    glm::vec3 pos(x, y, z);
+
+    PointLightSetting pls = {
+        pos, phong, att        
+    };
+
+    settings.push_back(pls);
+}
 
 ////////////////////
 ///// TEXTURES /////
@@ -264,17 +284,6 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setVec3("dirLight.specular"    , glm::vec3(1.0));
 
     // set point light(s) properties
-    //for (int plIdx = 0; plIdx < NR_POINT_LIGHTS; ++plIdx) {
-    //    std::string st = std::format("pointLights{}", plIdx);
-    //    objectShader.setVec3 (std::format("{}.position  = {}", st, glm::vec3(plIdx)));
-    //    objectShader.setVec3 (std::format("{}.ambient   = {}", st, glm::vec3(0.2)));
-    //    objectShader.setVec3 (std::format("{}.diffuse   = {}", st, glm::vec3(0.5)));
-    //    objectShader.setVec3 (std::format("{}.specular  = {}", st, glm::vec3(1.0)));
-    //    objectShader.setFloat(std::format("{}.constant  = {}", st, 1.0));
-    //    objectShader.setFloat(std::format("{}.linear    = {}", st, 0.09));
-    //    objectShader.setFloat(std::format("{}.quadratic = {}", st, 0.032));
-    //}
-
     // TODO: Condense this monstrosity please for the love of god
 /*
     objectShader.setVec3  ("pointLights[0].position" ,     pointLightPos[0] );
@@ -499,13 +508,13 @@ void setPointLights(const int MAX_POINT_LIGHTS, const PointLightSetting& pls, co
         snprintf(plChArr, sz, "pointLights[%d]", idx);
         std::string plStr(plChArr);
 
-        shaderProgram.setVec3 (plStr, pls.pos);
-        shaderProgram.setVec3 (plStr, pls.ambient);
-        shaderProgram.setVec3 (plStr, pls.diffuse);
-        shaderProgram.setVec3 (plStr, pls.specular);
-        shaderProgram.setFloat(plStr, pls.constant);
-        shaderProgram.setFloat(plStr, pls.linear);
-        shaderProgram.setFloat(plStr, pls.quadratic);
+        shaderProgram.setVec3 (plStr, pls.position);
+        shaderProgram.setVec3 (plStr, pls.phong.ambient);
+        shaderProgram.setVec3 (plStr, pls.phong.diffuse);
+        shaderProgram.setVec3 (plStr, pls.phong.specular);
+        shaderProgram.setFloat(plStr, pls.attenuation.constant);
+        shaderProgram.setFloat(plStr, pls.attenuation.linear);
+        shaderProgram.setFloat(plStr, pls.attenuation.quadratic);
         }
     }
 }

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -22,14 +22,22 @@ unsigned int loadTexture(std::string texPath);
 void setPointLights(int MAX_POINT_LIGHTS);
 
 // structs
-typedef struct PointLightSetting {
-    glm::vec3 pos;
-    glm::vec3 ambient;
-    glm::vec3 diffuse;
-    glm::vec3 specular;
+typedef struct Attenuation {
     float constant;
     float linear;
     float quadratic;
+} Attenuation;
+
+typedef struct Phong {
+    glm::vec3 ambient;
+    glm::vec3 diffuse;
+    glm::vec3 specular;
+} Phong;
+
+typedef struct PointLightSetting {
+    glm::vec3   pos;
+    Phong       phong;
+    Attenuation attenuation;
 } PointLightSetting;
 
 // settings

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -290,7 +290,6 @@ while (!glfwWindowShouldClose(window)) {
     setPointLights(settings, objectShader, NR_POINT_LIGHTS);
 
     // set spot light property
-    // TODO finish setting this up [do this one first]
     objectShader.setVec3("flashLight.position"    , camera->cameraPos);
     objectShader.setVec3("flashLight.direction"   , camera->cameraFront);
     objectShader.setVec3("flashLight.ambient"     , glm::vec3(0.2));

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -146,8 +146,8 @@ cubePos.reserve(nCubes);
 
 for (int i = 0; i < nCubes; i++) {
     int x, y, z;
-    float minV = -10.0f; 
-    float maxV = 10.0f;
+    float minV = -5.0f; 
+    float maxV =  5.0f;
 
     x = genRandFloat(minV, maxV);
     y = genRandFloat(minV, maxV);
@@ -252,7 +252,17 @@ while (!glfwWindowShouldClose(window)) {
 
     // draw object
     glBindVertexArray(objectVAO);
-    glDrawArrays(GL_TRIANGLES, 0, 36);
+
+    for (int i = 0; i < nCubes; i++) {
+        model = glm::mat4(1.0f);    
+        model = glm::translate(model, cubePos[i]);
+        
+        float angle = 20.0f * i;
+        model = glm::rotate(model, angle, glm::vec3(1.0f, 0.5f, 0.3f));
+        objectShader.setMat4("model", model);
+
+        glDrawArrays(GL_TRIANGLES, 0, 36);
+    }
 
     // update lamp shader
     lampShader.use();

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -210,7 +210,7 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.use();
 
     // set object lighting properties
-    objectShader.setVec3("light.position", glm::vec3(1.2f, 1.0f, 2.0f));
+    objectShader.setVec3("light.direction", -0.2f, -0.1f, -0.3f);
     objectShader.setVec3("light.ambient", 0.2f, 0.2f, 0.2f);
     objectShader.setVec3("light.diffuse", 0.5f, 0.5f, 0.5f);
     objectShader.setVec3("light.specular", 1.0f, 1.0f, 1.0f);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -289,6 +289,19 @@ while (!glfwWindowShouldClose(window)) {
     // set point light(s) properties
     setPointLights(settings, objectShader, NR_POINT_LIGHTS);
 
+    // set spot light property
+    // TODO finish setting this up [do this one first]
+    objectShader.setVec3("flashLight.position"    , camera->cameraPos);
+    objectShader.setVec3("flashLight.direction"   , camera->cameraFront);
+    objectShader.setVec3("flashLight.ambient"     , glm::vec3(0.2));
+    objectShader.setVec3("flashLight.diffuse"     , glm::vec3(0.5));
+    objectShader.setVec3("flashLight.specular"    , glm::vec3(1.0));
+    objectShader.setFloat("flashLight.constant"   , 1.0f);
+    objectShader.setFloat("flashLight.linear"     , 0.09f);
+    objectShader.setFloat("flashLight.quadratic"  , 0.032f);
+    objectShader.setFloat("flashLight.innerAngle" , glm::cos(glm::radians(12.0f)));
+    objectShader.setFloat("flashLight.outerAngle" , glm::cos(glm::radians(17.0f)));
+
     // set object material properties
     objectShader.setInt("material.diffuse", 0);
     objectShader.setInt("material.specular", 1);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -234,14 +234,14 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setVec3("sun.specular",    1.0f, 1.0f, 1.0f);
 
     // set point lighting properties
-    objectShader.setVec3("torch.position", -0.2f, -0.1f, -0.3f);
-    objectShader.setVec3("torch.ambient",   0.2f, 0.2f, 0.2f);
-    objectShader.setVec3("torch.diffuse",   0.5f, 0.5f, 0.5f);
-    objectShader.setVec3("torch.specular",  1.0f, 1.0f, 1.0f);
+    objectShader.setVec3("lamp.position", -0.2f, -0.1f, -0.3f);
+    objectShader.setVec3("lamp.ambient",   0.2f, 0.2f, 0.2f);
+    objectShader.setVec3("lamp.diffuse",   0.5f, 0.5f, 0.5f);
+    objectShader.setVec3("lamp.specular",  1.0f, 1.0f, 1.0f);
 
-    objectShader.setFloat("torch.constant",  1.0f);
-    objectShader.setFloat("torch.linear",    0.09f);
-    objectShader.setFloat("torch.quadratic", 0.032f);
+    objectShader.setFloat("lamp.constant",  1.0f);
+    objectShader.setFloat("lamp.linear",    0.09f);
+    objectShader.setFloat("lamp.quadratic", 0.032f);
 
 
     // set object material properties

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -282,9 +282,9 @@ while (!glfwWindowShouldClose(window)) {
 
     // set directional light properties 
     objectShader.setVec3("dirLight.direction"   , glm::vec3(1.0));
-    objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.2));
-    objectShader.setVec3("dirLight.diffuse"     , glm::vec3(0.5));
-    objectShader.setVec3("dirLight.specular"    , glm::vec3(1.0));
+    objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.05));
+    objectShader.setVec3("dirLight.diffuse"     , glm::vec3(0.2));
+    objectShader.setVec3("dirLight.specular"    , glm::vec3(0.5));
 
     // set point light(s) properties
     setPointLights(settings, objectShader, NR_POINT_LIGHTS);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -139,6 +139,24 @@ float vertices[] = {
     -0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f,  0.0f,  1.0f
 };
 
+// generate a bunch of random cube positions
+int nCubes = 15;
+std::vector<glm::vec3> cubePos;
+cubePos.reserve(nCubes);
+
+for (int i = 0; i < nCubes; i++) {
+    int x, y, z;
+    float minV = -10.0f; 
+    float maxV = 10.0f;
+
+    x = genRandFloat(minV, maxV);
+    y = genRandFloat(minV, maxV);
+    z = genRandFloat(minV, maxV);
+
+    glm::vec3 pos(x, y, z);
+    cubePos.push_back(pos);
+}
+
 
 ////////////////////
 ///// TEXTURES /////

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -212,7 +212,6 @@ glEnableVertexAttribArray(0);
 // unbind to prevent accidental state changes
 glBindVertexArray(0);
 
-
 ///////////////////////
 ///// RENDER LOOP /////
 ///////////////////////
@@ -237,7 +236,6 @@ while (!glfwWindowShouldClose(window)) {
     // use object shader
     objectShader.use();
 
-    // TODO: Make sure these values are correctly set
     // set directional light properties 
     objectShader.setVec3("dirLight.direction"   , glm::vec3(1.0));
     objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.2));
@@ -245,7 +243,6 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setVec3("dirLight.specular"    , glm::vec3(1.0));
 
     // set point light(s) properties
-    //const int NR_POINT_LIGHTS = 4;
     //for (int plIdx = 0; plIdx < NR_POINT_LIGHTS; ++plIdx) {
     //    std::string st = std::format("pointLights{}", plIdx);
     //    objectShader.setVec3 (std::format("{}.position  = {}", st, glm::vec3(plIdx)));

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -255,7 +255,7 @@ while (!glfwWindowShouldClose(window)) {
     //}
 
     // TODO: Condense this monstrosity please for the love of god
-    objectShader.setVec3  ("pointLights[0].position" ,     glm::vec3(1.0) );
+    objectShader.setVec3  ("pointLights[0].position" ,     pointLightPos[0] );
     objectShader.setVec3  ("pointLights[0].ambient"  ,     glm::vec3(0.2) );
     objectShader.setVec3  ("pointLights[0].diffuse"  ,     glm::vec3(0.5) );
     objectShader.setVec3  ("pointLights[0].specular" ,     glm::vec3(1.0) );
@@ -263,7 +263,7 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setFloat ("pointLights[0].linear"   ,     0.09     );
     objectShader.setFloat ("pointLights[0].quadratic",     0.032    );
 
-    objectShader.setVec3  ("pointLights[1].position" ,     glm::vec3(2.0) );
+    objectShader.setVec3  ("pointLights[1].position" ,     pointLightPos[1] );
     objectShader.setVec3  ("pointLights[1].ambient"  ,     glm::vec3(0.2) );
     objectShader.setVec3  ("pointLights[1].diffuse"  ,     glm::vec3(0.5) );
     objectShader.setVec3  ("pointLights[1].specular" ,     glm::vec3(1.0) );
@@ -271,7 +271,7 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setFloat ("pointLights[1].linear"   ,     0.09     );
     objectShader.setFloat ("pointLights[1].quadratic",     0.032    );
 
-    objectShader.setVec3  ("pointLights[2].position" ,     glm::vec3(3.0) );
+    objectShader.setVec3  ("pointLights[2].position" ,     pointLightPos[2] );
     objectShader.setVec3  ("pointLights[2].ambient"  ,     glm::vec3(0.2) );
     objectShader.setVec3  ("pointLights[2].diffuse"  ,     glm::vec3(0.5) );
     objectShader.setVec3  ("pointLights[2].specular" ,     glm::vec3(1.0) );
@@ -279,7 +279,7 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setFloat ("pointLights[2].linear"   ,     0.09     );
     objectShader.setFloat ("pointLights[2].quadratic",     0.032    );
 
-    objectShader.setVec3  ("pointLights[3].position" ,     glm::vec3(4.0) );
+    objectShader.setVec3  ("pointLights[3].position" ,     pointLightPos[3] );
     objectShader.setVec3  ("pointLights[3].ambient"  ,     glm::vec3(0.2) );
     objectShader.setVec3  ("pointLights[3].diffuse"  ,     glm::vec3(0.5) );
     objectShader.setVec3  ("pointLights[3].specular" ,     glm::vec3(1.0) );
@@ -317,23 +317,22 @@ while (!glfwWindowShouldClose(window)) {
         glDrawArrays(GL_TRIANGLES, 0, 36);
     }
 
-    // TODO: need to render 4 lamps 
     // update lamp shader
     lampShader.use();
 
-    model = glm::mat4(1.0f);
-    model = glm::translate(model, glm::vec3(1.2f, 1.0f, 2.0f));
-    model = glm::scale(model, glm::vec3(0.2f));
+    for (int lampIdx = 0; lampIdx < NR_POINT_LIGHTS; ++lampIdx) {
+        model = glm::mat4(1.0f);
+        model = glm::translate(model, pointLightPos[lampIdx]);
+        model = glm::scale(model, glm::vec3(0.2f));
 
-    lampShader.setMat4("model", model);
-    lampShader.setMat4("view", view);
-    lampShader.setMat4("projection", projection);
+        lampShader.setMat4("model", model);
+        lampShader.setMat4("view", view);
+        lampShader.setMat4("projection", projection);
+        lampShader.setVec3("lightColor", glm::vec3(1.0f));
 
-    lampShader.setVec3("lightColor", glm::vec3(1.0f));
-
-    // draw lamp
-    glBindVertexArray(lampVAO);
-    glDrawArrays(GL_TRIANGLES, 0, 36);
+        glBindVertexArray(lampVAO);
+        glDrawArrays(GL_TRIANGLES, 0, 36);
+    }
 
     // unbind vaos to prevent accidental state changes
     glBindVertexArray(0);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -16,6 +16,7 @@ void processInput(GLFWwindow *window);
 void logError(std::string comment);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos); // xpos and ypos are the mouse's current position
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
+float genRandFloat(float min, float max);
 unsigned int loadTexture(std::string texPath);
 
 // settings
@@ -358,4 +359,9 @@ unsigned int loadTexture(std::string texPath) {
     glBindTexture(GL_TEXTURE_2D, 0);
 
     return texture;
+}
+
+float genRandFloat(float min, float max) {
+    // Source: user "lastchance" - https://cplusplus.com/forum/general/242186/
+    return min + (max - min) * rand() / RAND_MAX;
 }

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -227,17 +227,56 @@ while (!glfwWindowShouldClose(window)) {
     // use object shader
     objectShader.use();
 
-    // set flashlight properties
-    objectShader.setVec3(  "light.position",    camera->cameraPos);
-    objectShader.setVec3(  "light.direction",   camera->cameraFront);
-    objectShader.setFloat( "light.cutOff",      glm::cos(glm::radians(18.0f)));
-    objectShader.setFloat( "light.outerCutOff", glm::cos(glm::radians(19.0f)));
-    objectShader.setVec3(  "light.ambient",     glm::vec3(0.2));
-    objectShader.setVec3(  "light.diffuse",     glm::vec3(0.7));
-    objectShader.setVec3(  "light.specular",    glm::vec3(1.0));
-    objectShader.setFloat( "light.constant",    1.0f);
-    objectShader.setFloat( "light.linear",      0.09f);
-    objectShader.setFloat( "light.quadratic",   0.032f);
+    // set directional light properties 
+    objectShader.setVec3("dirLight.direction"   , glm::vec3(1.0));
+    objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.2));
+    objectShader.setVec3("dirLight.diffuse"     , glm::vec3(0.5));
+    objectShader.setVec3("dirLight.specular"    , glm::vec3(1.0));
+
+    // set point light(s) properties
+    //const int NR_POINT_LIGHTS = 4;
+    //for (int plIdx = 0; plIdx < NR_POINT_LIGHTS; ++plIdx) {
+    //    std::string st = std::format("pointLights{}", plIdx);
+    //    objectShader.setVec3 (std::format("{}.position  = {}", st, glm::vec3(plIdx)));
+    //    objectShader.setVec3 (std::format("{}.ambient   = {}", st, glm::vec3(0.2)));
+    //    objectShader.setVec3 (std::format("{}.diffuse   = {}", st, glm::vec3(0.5)));
+    //    objectShader.setVec3 (std::format("{}.specular  = {}", st, glm::vec3(1.0)));
+    //    objectShader.setFloat(std::format("{}.constant  = {}", st, 1.0));
+    //    objectShader.setFloat(std::format("{}.linear    = {}", st, 0.09));
+    //    objectShader.setFloat(std::format("{}.quadratic = {}", st, 0.032));
+    //}
+
+    objectShader.setVec3  ("pointLights[0].position" ,     glm::vec3(1.0) );
+    objectShader.setVec3  ("pointLights[0].ambient"  ,     glm::vec3(0.2) );
+    objectShader.setVec3  ("pointLights[0].diffuse"  ,     glm::vec3(0.5) );
+    objectShader.setVec3  ("pointLights[0].specular" ,     glm::vec3(1.0) );
+    objectShader.setFloat ("pointLights[0].constant" ,     1.0      );
+    objectShader.setFloat ("pointLights[0].linear"   ,     0.09     );
+    objectShader.setFloat ("pointLights[0].quadratic",     0.032    );
+
+    objectShader.setVec3  ("pointLights[1].position" ,     glm::vec3(2.0) );
+    objectShader.setVec3  ("pointLights[1].ambient"  ,     glm::vec3(0.2) );
+    objectShader.setVec3  ("pointLights[1].diffuse"  ,     glm::vec3(0.5) );
+    objectShader.setVec3  ("pointLights[1].specular" ,     glm::vec3(1.0) );
+    objectShader.setFloat ("pointLights[1].constant" ,     1.0      );
+    objectShader.setFloat ("pointLights[1].linear"   ,     0.09     );
+    objectShader.setFloat ("pointLights[1].quadratic",     0.032    );
+
+    objectShader.setVec3  ("pointLights[2].position" ,     glm::vec3(3.0) );
+    objectShader.setVec3  ("pointLights[2].ambient"  ,     glm::vec3(0.2) );
+    objectShader.setVec3  ("pointLights[2].diffuse"  ,     glm::vec3(0.5) );
+    objectShader.setVec3  ("pointLights[2].specular" ,     glm::vec3(1.0) );
+    objectShader.setFloat ("pointLights[2].constant" ,     1.0      );
+    objectShader.setFloat ("pointLights[2].linear"   ,     0.09     );
+    objectShader.setFloat ("pointLights[2].quadratic",     0.032    );
+
+    objectShader.setVec3  ("pointLights[3].position" ,     glm::vec3(4.0) );
+    objectShader.setVec3  ("pointLights[3].ambient"  ,     glm::vec3(0.2) );
+    objectShader.setVec3  ("pointLights[3].diffuse"  ,     glm::vec3(0.5) );
+    objectShader.setVec3  ("pointLights[3].specular" ,     glm::vec3(1.0) );
+    objectShader.setFloat ("pointLights[3].constant" ,     1.0      );
+    objectShader.setFloat ("pointLights[3].linear"   ,     0.09     );
+    objectShader.setFloat ("pointLights[3].quadratic",     0.032    );
 
     // set object material properties
     objectShader.setInt("material.diffuse", 0);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -4,6 +4,7 @@
 #include "../../../include/learnopengl/camera.h"
 #include "../../../include/stb_image/stb_image.h"
 
+#include <cstdio>
 #include <iostream>
 #include <filesystem>
 #include <ostream>
@@ -445,4 +446,37 @@ unsigned int loadTexture(std::string texPath) {
 float genRandFloat(float min, float max) {
     // Source: user "lastchance" - https://cplusplus.com/forum/general/242186/
     return min + (max - min) * rand() / RAND_MAX;
+}
+
+// TODO: write a function to set the options for pointlight(s) shader
+void setPointLights(int MAX_POINT_LIGHTS) {
+    const std::vector<std::string> settings = {
+        "position",
+        "ambient",
+        "diffuse",
+        "specular",
+        "constant",
+        "linear",
+        "quadratic"
+    };
+
+    const int sz = (std::string("pointLights[n]")).size();
+    char plStr[sz];
+
+    // NOTE: this is super restrictive, but i can't imagine myself adding more than 10 point lights for the
+    //  scope of this project anyways
+    if (MAX_POINT_LIGHTS > 9) {
+        logError("SETPOINTLIGHTS::ERROR::MAX_POINT_LIGHTS_EXCEEDED");
+        exit(1);
+    }
+
+    for (int idx = 0; idx < MAX_POINT_LIGHTS; ++idx) {
+        snprintf(plStr, sz, "pointLights[%d]", idx);
+
+        // ... 
+
+
+
+
+    }
 }

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -227,6 +227,7 @@ while (!glfwWindowShouldClose(window)) {
     // use object shader
     objectShader.use();
 
+    // TODO: Make sure these values are correctly set
     // set directional light properties 
     objectShader.setVec3("dirLight.direction"   , glm::vec3(1.0));
     objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.2));
@@ -246,6 +247,7 @@ while (!glfwWindowShouldClose(window)) {
     //    objectShader.setFloat(std::format("{}.quadratic = {}", st, 0.032));
     //}
 
+    // TODO: Condense this monstrosity please for the love of god
     objectShader.setVec3  ("pointLights[0].position" ,     glm::vec3(1.0) );
     objectShader.setVec3  ("pointLights[0].ambient"  ,     glm::vec3(0.2) );
     objectShader.setVec3  ("pointLights[0].diffuse"  ,     glm::vec3(0.5) );
@@ -308,6 +310,7 @@ while (!glfwWindowShouldClose(window)) {
         glDrawArrays(GL_TRIANGLES, 0, 36);
     }
 
+    // TODO: need to render 4 lamps 
     // update lamp shader
     lampShader.use();
 

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -157,6 +157,16 @@ for (int i = 0; i < nCubes; i++) {
     cubePos.push_back(pos);
 }
 
+// generate point light positions
+const int NR_POINT_LIGHTS = 4;
+std::vector<glm::vec3> pointLightPos;
+pointLightPos.reserve(NR_POINT_LIGHTS);
+
+for (int pointLightIdx = 0; pointLightIdx < NR_POINT_LIGHTS; ++pointLightIdx) {
+    glm::vec3 newPos(genRandFloat(-3, 3), genRandFloat(-3, 3), genRandFloat(-3, 3));
+    pointLightPos.push_back(newPos);
+}
+
 
 ////////////////////
 ///// TEXTURES /////

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -281,10 +281,10 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.use();
 
     // set directional light properties 
-    objectShader.setVec3("dirLight.direction"   , glm::vec3(1.0));
-    objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.05));
-    objectShader.setVec3("dirLight.diffuse"     , glm::vec3(0.2));
-    objectShader.setVec3("dirLight.specular"    , glm::vec3(0.5));
+    objectShader.setVec3("dirLight.direction"   , glm::vec3(10.0));
+    objectShader.setVec3("dirLight.ambient"     , glm::vec3(0.1));
+    objectShader.setVec3("dirLight.diffuse"     , glm::vec3(0.3));
+    objectShader.setVec3("dirLight.specular"    , glm::vec3(0.7));
 
     // set point light(s) properties
     setPointLights(settings, objectShader, NR_POINT_LIGHTS);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -246,7 +246,8 @@ while (!glfwWindowShouldClose(window)) {
     // set flashlight properties
     objectShader.setVec3("torch.position", camera->cameraPos);
     objectShader.setVec3("torch.direction", camera->cameraFront);
-    objectShader.setFloat("torch.cutOff", glm::cos(glm::radians(20.0f)));
+    objectShader.setFloat("torch.cutOff", glm::cos(glm::radians(18.0f)));
+    objectShader.setFloat("torch.outerCutOff", glm::cos(glm::radians(19.0f)));
     objectShader.setVec3("torch.ambient",  glm::vec3(0.2));
     objectShader.setVec3("torch.diffuse",  glm::vec3(0.5));
     objectShader.setVec3("torch.specular", glm::vec3(1.0));

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -294,7 +294,7 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setVec3("flashLight.position"    , camera->cameraPos);
     objectShader.setVec3("flashLight.direction"   , camera->cameraFront);
     objectShader.setVec3("flashLight.ambient"     , glm::vec3(0.2));
-    objectShader.setVec3("flashLight.diffuse"     , glm::vec3(0.5));
+    objectShader.setVec3("flashLight.diffuse"     , glm::vec3(0.9));
     objectShader.setVec3("flashLight.specular"    , glm::vec3(1.0));
     objectShader.setFloat("flashLight.constant"   , 1.0f);
     objectShader.setFloat("flashLight.linear"     , 0.09f);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -449,7 +449,6 @@ float genRandFloat(float min, float max) {
     return min + (max - min) * rand() / RAND_MAX;
 }
 
-// TODO: write a function to set the options for pointlight(s) shader
 void setPointLights(const std::vector<PointLightSetting>& settings, const Shader& shaderProgram, const int MAX_POINT_LIGHTS) { // pls uwu 🥺👉👈
     // NOTE: this is super restrictive, but i can't imagine myself adding more than 10 point lights for the
     //  scope of this project anyways

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -243,6 +243,13 @@ while (!glfwWindowShouldClose(window)) {
     objectShader.setFloat("lamp.linear",    0.09f);
     objectShader.setFloat("lamp.quadratic", 0.032f);
 
+    // set flashlight properties
+    objectShader.setVec3("torch.position", camera->cameraPos);
+    objectShader.setVec3("torch.direction", camera->cameraFront);
+    objectShader.setFloat("torch.cutOff", glm::cos(glm::radians(20.0f)));
+    objectShader.setVec3("torch.ambient",  glm::vec3(0.2));
+    objectShader.setVec3("torch.diffuse",  glm::vec3(0.5));
+    objectShader.setVec3("torch.specular", glm::vec3(1.0));
 
     // set object material properties
     objectShader.setInt("material.diffuse", 0);

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -39,6 +39,7 @@ void processInput(GLFWwindow *window);
 void logError(std::string comment);
 void mouse_callback(GLFWwindow* window, double xpos, double ypos); // xpos and ypos are the mouse's current position
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
+void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);
 float genRandFloat(float min, float max);
 unsigned int loadTexture(std::string texPath);
 void setPointLights(const std::vector<PointLightSetting>& settings, const Shader& shaderProgram, const int MAX_POINT_LIGHTS);
@@ -55,6 +56,10 @@ float lastFrame = 0.0f;
 
 // camera
 Camera* camera = new Camera(SCR_WIDTH, SCR_HEIGHT);
+
+// toggles flashlight state in object fragment
+bool flashLightOn = false;
+
 
 int main() {
 //////////////////////////////
@@ -89,6 +94,7 @@ glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED); // hide mouse and capture its movement
 glfwSetCursorPosCallback(window, mouse_callback);
 glfwSetScrollCallback(window, scroll_callback);
+glfwSetKeyCallback(window, key_callback);
 
 
 ////////////////
@@ -289,17 +295,20 @@ while (!glfwWindowShouldClose(window)) {
     // set point light(s) properties
     setPointLights(settings, objectShader, NR_POINT_LIGHTS);
 
-    // set spot light property
-    objectShader.setVec3("flashLight.position"    , camera->cameraPos);
-    objectShader.setVec3("flashLight.direction"   , camera->cameraFront);
-    objectShader.setVec3("flashLight.ambient"     , glm::vec3(0.2));
-    objectShader.setVec3("flashLight.diffuse"     , glm::vec3(0.9));
-    objectShader.setVec3("flashLight.specular"    , glm::vec3(1.0));
-    objectShader.setFloat("flashLight.constant"   , 1.0f);
-    objectShader.setFloat("flashLight.linear"     , 0.09f);
-    objectShader.setFloat("flashLight.quadratic"  , 0.032f);
-    objectShader.setFloat("flashLight.innerAngle" , glm::cos(glm::radians(12.0f)));
-    objectShader.setFloat("flashLight.outerAngle" , glm::cos(glm::radians(17.0f)));
+    // set spot light property (flashlight)
+    objectShader.setBool("flashLightOn", flashLightOn);
+
+    if (flashLightOn) {
+        objectShader.setVec3("flashLight.position"    , camera->cameraPos);
+        objectShader.setVec3("flashLight.direction"   , camera->cameraFront);
+        objectShader.setVec3("flashLight.diffuse"     , glm::vec3(1.0));
+        objectShader.setVec3("flashLight.specular"    , glm::vec3(1.0));
+        objectShader.setFloat("flashLight.constant"   , 1.0f);
+        objectShader.setFloat("flashLight.linear"     , 0.09f);
+        objectShader.setFloat("flashLight.quadratic"  , 0.032f);
+        objectShader.setFloat("flashLight.innerAngle" , glm::cos(glm::radians(12.0f)));
+        objectShader.setFloat("flashLight.outerAngle" , glm::cos(glm::radians(17.0f)));
+    }
 
     // set object material properties
     objectShader.setInt("material.diffuse", 0);
@@ -412,6 +421,16 @@ void mouse_callback(GLFWwindow* window, double xposIn, double yposIn) { // xpos 
 
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset) {
     camera->processScrollMovement(yoffset, 0.25f);
+}
+
+void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods) {
+    if (action == GLFW_RELEASE) {
+        return;
+    }
+
+    if (key == GLFW_KEY_F) {
+        flashLightOn = !flashLightOn;
+    }
 }
 
 unsigned int loadTexture(std::string texPath) {

--- a/src/2.lighting/16.light_casters/main.cpp
+++ b/src/2.lighting/16.light_casters/main.cpp
@@ -1,0 +1,361 @@
+#include "../../../include/glad/glad.h"
+#include "../../../include/glfw/glfw3.h"
+#include "../../../include/learnopengl/shader.h"
+#include "../../../include/learnopengl/camera.h"
+#include "../../../include/stb_image/stb_image.h"
+
+#include <iostream>
+#include <filesystem>
+#include <ostream>
+#include <string>
+#include <cstdlib>
+#include <ctime>
+
+void framebuffer_size_callback(GLFWwindow* window, int width, int height);
+void processInput(GLFWwindow *window);
+void logError(std::string comment);
+void mouse_callback(GLFWwindow* window, double xpos, double ypos); // xpos and ypos are the mouse's current position
+void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
+unsigned int loadTexture(std::string texPath);
+
+// settings
+const unsigned int SCR_WIDTH    = 1200;
+const unsigned int SCR_HEIGHT   = 800;
+const std::string shaderPath    = std::filesystem::current_path().string() + "/../src/2.lighting/16.light_casters/"; // NOTE: make sure to update this correctly!
+const std::string texturePath   = std::filesystem::current_path().string() + "/../resources/textures/"; // NOTE: make sure to update this correctly!
+
+// frames
+float deltaTime = 0.0f;
+float lastFrame = 0.0f;
+
+// camera
+Camera* camera = new Camera(SCR_WIDTH, SCR_HEIGHT);
+
+int main() {
+//////////////////////////////
+///// PRE-INITIALIZATION /////
+//////////////////////////////
+// set random seed
+srand(static_cast<unsigned int>(time(0)));
+
+
+////////////////
+///// GLFW /////
+////////////////
+// initialize and configure
+glfwInit();
+glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+#ifdef __APPLE__
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#endif
+
+// window creation
+GLFWwindow* window = glfwCreateWindow(SCR_WIDTH, SCR_HEIGHT, "LearnOpenGL", NULL, NULL);
+if (window == NULL) {
+    logError("Failed to create GLFW window");
+    glfwTerminate();
+    return -1;
+}
+glfwMakeContextCurrent(window);
+glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
+glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED); // hide mouse and capture its movement
+glfwSetCursorPosCallback(window, mouse_callback);
+glfwSetScrollCallback(window, scroll_callback);
+
+
+////////////////
+///// GLAD /////
+////////////////
+// load all OpenGL function pointers
+if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+    logError("Failed to initialize GLAD");
+    return -1;
+}
+
+
+//////////////////
+///// OPENGL /////
+//////////////////
+glEnable(GL_DEPTH_TEST);
+
+
+//////////////////
+///// SHADER /////
+//////////////////
+// build and compile our shader program
+Shader objectShader( (shaderPath + "object.vert").c_str(), (shaderPath + "object.frag").c_str() );
+Shader lampShader( (shaderPath + "lamp.vert").c_str(), (shaderPath + "lamp.frag").c_str() );
+
+////////////////////
+///// VERTICES /////
+////////////////////
+// set up vertex data
+float vertices[] = {
+    // positions          // normals           // texture coords
+    -0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  0.0f,  0.0f,
+     0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  1.0f,  0.0f,
+     0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  1.0f,  1.0f,
+     0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  1.0f,  1.0f,
+    -0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  0.0f,  1.0f,
+    -0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  0.0f,  0.0f,
+
+    -0.5f, -0.5f,  0.5f,  0.0f,  0.0f,  1.0f,  0.0f,  0.0f,
+     0.5f, -0.5f,  0.5f,  0.0f,  0.0f,  1.0f,  1.0f,  0.0f,
+     0.5f,  0.5f,  0.5f,  0.0f,  0.0f,  1.0f,  1.0f,  1.0f,
+     0.5f,  0.5f,  0.5f,  0.0f,  0.0f,  1.0f,  1.0f,  1.0f,
+    -0.5f,  0.5f,  0.5f,  0.0f,  0.0f,  1.0f,  0.0f,  1.0f,
+    -0.5f, -0.5f,  0.5f,  0.0f,  0.0f,  1.0f,  0.0f,  0.0f,
+
+    -0.5f,  0.5f,  0.5f, -1.0f,  0.0f,  0.0f,  1.0f,  0.0f,
+    -0.5f,  0.5f, -0.5f, -1.0f,  0.0f,  0.0f,  1.0f,  1.0f,
+    -0.5f, -0.5f, -0.5f, -1.0f,  0.0f,  0.0f,  0.0f,  1.0f,
+    -0.5f, -0.5f, -0.5f, -1.0f,  0.0f,  0.0f,  0.0f,  1.0f,
+    -0.5f, -0.5f,  0.5f, -1.0f,  0.0f,  0.0f,  0.0f,  0.0f,
+    -0.5f,  0.5f,  0.5f, -1.0f,  0.0f,  0.0f,  1.0f,  0.0f,
+
+     0.5f,  0.5f,  0.5f,  1.0f,  0.0f,  0.0f,  1.0f,  0.0f,
+     0.5f,  0.5f, -0.5f,  1.0f,  0.0f,  0.0f,  1.0f,  1.0f,
+     0.5f, -0.5f, -0.5f,  1.0f,  0.0f,  0.0f,  0.0f,  1.0f,
+     0.5f, -0.5f, -0.5f,  1.0f,  0.0f,  0.0f,  0.0f,  1.0f,
+     0.5f, -0.5f,  0.5f,  1.0f,  0.0f,  0.0f,  0.0f,  0.0f,
+     0.5f,  0.5f,  0.5f,  1.0f,  0.0f,  0.0f,  1.0f,  0.0f,
+
+    -0.5f, -0.5f, -0.5f,  0.0f, -1.0f,  0.0f,  0.0f,  1.0f,
+     0.5f, -0.5f, -0.5f,  0.0f, -1.0f,  0.0f,  1.0f,  1.0f,
+     0.5f, -0.5f,  0.5f,  0.0f, -1.0f,  0.0f,  1.0f,  0.0f,
+     0.5f, -0.5f,  0.5f,  0.0f, -1.0f,  0.0f,  1.0f,  0.0f,
+    -0.5f, -0.5f,  0.5f,  0.0f, -1.0f,  0.0f,  0.0f,  0.0f,
+    -0.5f, -0.5f, -0.5f,  0.0f, -1.0f,  0.0f,  0.0f,  1.0f,
+
+    -0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f,  0.0f,  1.0f,
+     0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f,  1.0f,  1.0f,
+     0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,  1.0f,  0.0f,
+     0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,  1.0f,  0.0f,
+    -0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,  0.0f,  0.0f,
+    -0.5f,  0.5f, -0.5f,  0.0f,  1.0f,  0.0f,  0.0f,  1.0f
+};
+
+
+////////////////////
+///// TEXTURES /////
+////////////////////
+// container texture
+unsigned int texture = loadTexture((texturePath + "container2.png"));
+
+// container specular texture
+unsigned int specularTexture = loadTexture((texturePath + "container2_specular.png"));
+
+///////////////
+///// VBO /////
+///////////////
+unsigned int VBO;
+glGenBuffers(1, &VBO);
+glBindBuffer(GL_ARRAY_BUFFER, VBO);
+glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+///////////////
+///// VAO /////
+///////////////
+// generate VAOs
+unsigned int objectVAO, lampVAO;
+glGenVertexArrays(1, &objectVAO);
+glGenVertexArrays(1, &lampVAO);
+
+// set object VAO
+glBindVertexArray(objectVAO);
+
+glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8*sizeof(float), (void*)0);
+glEnableVertexAttribArray(0);
+glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8*sizeof(float), (void*)(3*sizeof(float)));
+glEnableVertexAttribArray(1);
+glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8*sizeof(float), (void*)(6*sizeof(float)));
+glEnableVertexAttribArray(2);
+
+// set lamp VAO
+glBindVertexArray(lampVAO);
+
+glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8*sizeof(float), (void*)0);
+glEnableVertexAttribArray(0);
+
+// unbind to prevent accidental state changes
+glBindVertexArray(0);
+
+
+///////////////////////
+///// RENDER LOOP /////
+///////////////////////
+while (!glfwWindowShouldClose(window)) {
+    // update delta time
+    float currentFrame = static_cast<float>(glfwGetTime());
+    deltaTime = currentFrame - lastFrame;
+    lastFrame = currentFrame;
+
+    // input
+    processInput(window);
+
+    // set background
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    // matrices
+    glm::mat4 model         = glm::mat4(1.0f);
+    glm::mat4 view          = camera->getViewMatrix();
+    glm::mat4 projection    = camera->getProjectionMatrix();
+
+    // use object shader
+    objectShader.use();
+
+    // set object lighting properties
+    objectShader.setVec3("light.position", glm::vec3(1.2f, 1.0f, 2.0f));
+    objectShader.setVec3("light.ambient", 0.2f, 0.2f, 0.2f);
+    objectShader.setVec3("light.diffuse", 0.5f, 0.5f, 0.5f);
+    objectShader.setVec3("light.specular", 1.0f, 1.0f, 1.0f);
+
+    // set object material properties
+    objectShader.setInt("material.diffuse", 0);
+    objectShader.setInt("material.specular", 1);
+    objectShader.setFloat("material.shininess", 64.0f);
+
+    // set object position
+    objectShader.setVec3("viewPos", camera->cameraPos);
+    objectShader.setMat4("model", model);
+    objectShader.setMat4("view", view);
+    objectShader.setMat4("projection", projection);
+
+    // bind texture
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, texture);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, specularTexture);
+
+    // draw object
+    glBindVertexArray(objectVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 36);
+
+    // update lamp shader
+    lampShader.use();
+
+    model = glm::mat4(1.0f);
+    model = glm::translate(model, glm::vec3(1.2f, 1.0f, 2.0f));
+    model = glm::scale(model, glm::vec3(0.2f));
+
+    lampShader.setMat4("model", model);
+    lampShader.setMat4("view", view);
+    lampShader.setMat4("projection", projection);
+
+    lampShader.setVec3("lightColor", glm::vec3(1.0f));
+
+    // draw lamp
+    glBindVertexArray(lampVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 36);
+
+    // unbind vaos to prevent accidental state changes
+    glBindVertexArray(0);
+
+    // glfw: swap buffers and poll IO events (keys pressed/released, mouse moved etc.)
+    // -------------------------------------------------------------------------------
+    glfwSwapBuffers(window);
+    glfwPollEvents();
+}
+
+// de-allocate all resources once they've outlived their purpose:
+// ------------------------------------------------------------------------
+glDeleteBuffers(1, &VBO);
+glDeleteVertexArrays(1, &objectVAO);
+glDeleteVertexArrays(1, &lampVAO);
+
+
+// glfw: terminate, clearing all previously allocated GLFW resources.
+// ------------------------------------------------------------------
+glfwTerminate();
+return 0;
+}
+
+// process all input: query GLFW whether relevant keys are pressed/released this frame and react accordingly
+// ---------------------------------------------------------------------------------------------------------
+void processInput(GLFWwindow *window) {
+    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+        glfwSetWindowShouldClose(window, true);
+
+    if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS)
+        camera->processKeyboard(FORWARD, deltaTime);
+
+    if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS)
+        camera->processKeyboard(BACKWARD, deltaTime);
+
+    if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS)
+        camera->processKeyboard(LEFT, deltaTime);
+
+    if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS)
+        camera->processKeyboard(RIGHT, deltaTime);
+
+    if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS)
+        camera->processKeyboard(UP, deltaTime);
+
+    if (glfwGetKey(window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS)
+        camera->processKeyboard(DOWN, deltaTime);
+}
+
+// glfw: whenever the window size changed (by OS or user resize) this callback function executes
+// ---------------------------------------------------------------------------------------------
+void framebuffer_size_callback(GLFWwindow* window, int width, int height) {
+    glViewport(0, 0, width, height);
+}
+
+// log out red text to standard output when there's an error
+void logError(std::string comment) {
+    std::cout << "\033[1;31m" << comment << "\033[0m" << std::endl;
+}
+
+void mouse_callback(GLFWwindow* window, double xposIn, double yposIn) { // xpos and ypos are the mouse's current position
+    camera->processMouseMovement(static_cast<float>(xposIn), static_cast<float>(yposIn), true);
+}
+
+void scroll_callback(GLFWwindow* window, double xoffset, double yoffset) {
+    camera->processScrollMovement(yoffset, 0.25f);
+}
+
+unsigned int loadTexture(std::string texPath) {
+    // read in texture image
+    int texWidth, texHeight, nChannels;
+    unsigned char* data = stbi_load(texPath.c_str(), &texWidth, &texHeight, &nChannels, 0);
+
+    if (!data) {
+        std::cout << "STBI_LOAD::ERROR: Unable to load texture" << std::endl;
+        exit(1);
+    }
+
+    int format;
+    switch (nChannels) {
+        case 3: 
+            format = GL_RGB;
+        case 4: 
+            format = GL_RGBA;
+    }
+
+    // create and bind texture
+    unsigned int texture;
+    glGenTextures(1, &texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    // wrapping behavior
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_MIRRORED_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_MIRRORED_REPEAT);
+
+    // filtering behavior
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    // load image
+    glTexImage2D(GL_TEXTURE_2D, 0, format, texWidth, texHeight, 0, format, GL_UNSIGNED_BYTE, data);
+    glGenerateMipmap(GL_TEXTURE_2D);
+
+    // clean-up
+    stbi_image_free(data);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    return texture;
+}

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -136,7 +136,6 @@ vec3 CalcPointLight(PointLight light, vec3 normal, vec3 viewDir) {
     return (ambient + diffuse + specular);
 }
 
-// TODO: TEST THIS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! NOT SURE IF IT WORKS!!!! !??!?!?! !!!!
 vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 viewDir) {
     // ambient
     vec3 ambient = light.ambient * vec3(texture(material.diffuse, TexCoord));

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -34,21 +34,17 @@ struct PointLight {
     float quadratic;
 }
 
-// TODO: Write up a function to calculate the SpotLight.
-// In this case, I want to create a flashlight, so it'll be attached to 
-//  the player... GOODLUCK!
-
-struct SpotLight {
-    vec3 position;
-    vec3 ambient;
-    vec3 diffuse;
-    vec3 specular;
-    float constant;
-    float linear;
-    float quadratic;
-    float innerAngle;
-    float outerAngle;
-}
+//struct SpotLight {
+//    vec3 position;
+//    vec3 ambient;
+//    vec3 diffuse;
+//    vec3 specular;
+//    float constant;
+//    float linear;
+//    float quadratic;
+//    float innerAngle;
+//    float outerAngle;
+//}
 
 // View position
 uniform vec3 viewPos;
@@ -59,7 +55,11 @@ uniform Material material;
 // Lighting
 uniform DirectionalLight dirLight;
 uniform PointLight pointLight;
-uniform SpotLight flashLight; // attached to the player
+
+// TODO: Write up a function to calculate the SpotLight.
+// In this case, I want to create a flashlight, so it'll be attached to 
+//  the player... GOODLUCK!
+//uniform SpotLight flashLight; // attached to the player
 
 // ----- FRAGMENT SHADER MAIN ----- 
 void main() {
@@ -112,3 +112,10 @@ vec3 CalcPointLight(PointLight light, vec3 normal, vec3 viewDir) {
 
     return (ambient + diffuse + specular);
 }
+
+//vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 viewDir) {
+//    // diffuse
+//
+//    // specular
+//    
+//}

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -8,7 +8,8 @@ struct Material {
 };
 
 struct Light {
-    vec3 position;
+    //vec3 position;
+    vec3 direction;
     vec3 ambient;
     vec3 diffuse;
     vec3 specular;
@@ -30,7 +31,7 @@ void main()
   	
     // --- diffuse ---
     vec3 norm             = normalize(Normal);
-    vec3 lightDir         = normalize(light.position - FragPos);
+    vec3 lightDir         = normalize(-light.direction);
     float diff            = max(dot(norm, lightDir), 0.0);
     vec3 diffuse          = light.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -33,7 +33,7 @@ uniform vec3 viewPos;
 
 uniform Material material;
 uniform DirectionalLight sun;
-uniform PointLight torch;
+uniform PointLight lamp;
 
 void main()
 {
@@ -57,24 +57,24 @@ void main()
 
 
     // attenuation
-    float distance        = length(torch.position - FragPos);
-    float attenuation     = 1.0 / (torch.constant + torch.linear * distance + 
-                                    torch.quadratic * (distance * distance));
+    float distance        = length(lamp.position - FragPos);
+    float attenuation     = 1.0 / (lamp.constant + lamp.linear * distance + 
+                                    lamp.quadratic * (distance * distance));
 
     // --- ambient --- 
-    vec3 ambient          = torch.ambient * vec3(texture(material.diffuse, TexCoord));
+    vec3 ambient          = lamp.ambient * vec3(texture(material.diffuse, TexCoord));
   	
     // --- diffuse ---
     vec3 norm             = normalize(Normal);
-    vec3 lightDir         = normalize(torch.position - FragPos);
+    vec3 lightDir         = normalize(lamp.position - FragPos);
     float diff            = max(dot(norm, lightDir), 0.0);
-    vec3 diffuse          = torch.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
+    vec3 diffuse          = lamp.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
 
     // --- specular ---
     vec3 viewDir          = normalize(viewPos - FragPos);
     vec3 reflectDir       = reflect(-lightDir, norm);
     float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    vec3 specular         = torch.specular * spec * vec3(texture(material.specular, TexCoord));
+    vec3 specular         = lamp.specular * spec * vec3(texture(material.specular, TexCoord));
 
     // --- apply ---
     ambient *= attenuation;

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -134,6 +134,7 @@ vec3 CalcPointLight(PointLight light, vec3 normal, vec3 viewDir) {
     return (ambient + diffuse + specular);
 }
 
+// TODO: TEST THIS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! NOT SURE IF IT WORKS!!!! !??!?!?! !!!!
 vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 viewDir) {
     // ambient
     glm::vec3 ambient = light.ambient * vec3(texture(material.ambient, TexCoord));

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -34,6 +34,22 @@ struct PointLight {
     float quadratic;
 }
 
+// TODO: Write up a function to calculate the SpotLight.
+// In this case, I want to create a flashlight, so it'll be attached to 
+//  the player... GOODLUCK!
+
+struct SpotLight {
+    vec3 position;
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+    float constant;
+    float linear;
+    float quadratic;
+    float innerAngle;
+    float outerAngle;
+}
+
 // View position
 uniform vec3 viewPos;
 
@@ -43,6 +59,7 @@ uniform Material material;
 // Lighting
 uniform DirectionalLight dirLight;
 uniform PointLight pointLight;
+uniform SpotLight flashLight; // attached to the player
 
 // ----- FRAGMENT SHADER MAIN ----- 
 void main() {

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -29,6 +29,7 @@ struct FlashLight {
     vec3 position; 
     vec3 direction; 
     float cutOff;
+    float outerCutOff;
 
     vec3 ambient;
     vec3 diffuse;
@@ -50,6 +51,8 @@ void main()
 {
     vec3 torchDir = normalize(torch.position - FragPos);
     float theta = dot(torchDir, normalize(-torch.direction));
+    float epsilon = torch.cutOff - torch.outerCutOff;
+    float intensity = clamp((theta - torch.outerCutOff) / epsilon, 0.0, 1.0);
 
     if (theta > torch.cutOff)
     {    
@@ -68,11 +71,13 @@ void main()
         vec3 specular = torch.specular * spec * vec3(texture(material.specular, TexCoord));  
         
         // attenuation
-        float distance    = length(torch.position - FragPos);
-        float attenuation = 1.0 / (lamp.constant + lamp.linear * distance + lamp.quadratic * (distance * distance));    
+        //float distance    = length(torch.position - FragPos);
+        //float attenuation = 1.0 / (lamp.constant + lamp.linear * distance + lamp.quadratic * (distance * distance));    
+        //diffuse *= attenuation;
+        //specular *= attenuation;   
 
-        diffuse *= attenuation;
-        specular *= attenuation;   
+        diffuse *= intensity;
+        specular *= intensity;   
             
         vec3 result = ambient + diffuse + specular;
         FragColor = vec4(result, 1.0);

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -7,15 +7,13 @@ struct Material {
     float shininess;
 };
 
-struct DirectionalLight {
-    vec3 direction;
-    vec3 ambient;
-    vec3 diffuse;
-    vec3 specular;
-};
+struct Light {
+    vec3 position; 
+    vec3 direction; 
 
-struct PointLight {
-    vec3 position;
+    float cutOff;
+    float outerCutOff;
+
     vec3 ambient;
     vec3 diffuse;
     vec3 specular;
@@ -25,17 +23,6 @@ struct PointLight {
     float quadratic;
 };
 
-struct FlashLight {
-    vec3 position; 
-    vec3 direction; 
-    float cutOff;
-    float outerCutOff;
-
-    vec3 ambient;
-    vec3 diffuse;
-    vec3 specular;
-};
-
 in vec3 FragPos;
 in vec3 Normal;
 in vec2 TexCoord;
@@ -43,93 +30,39 @@ in vec2 TexCoord;
 uniform vec3 viewPos;
 
 uniform Material material;
-uniform DirectionalLight sun;
-uniform PointLight lamp;
-uniform FlashLight torch;
+uniform Light light;
 
 void main()
 {
-    vec3 torchDir = normalize(torch.position - FragPos);
-    float theta = dot(torchDir, normalize(-torch.direction));
-    float epsilon = torch.cutOff - torch.outerCutOff;
-    float intensity = clamp((theta - torch.outerCutOff) / epsilon, 0.0, 1.0);
 
-    if (theta > torch.cutOff)
-    {    
-        // ambient
-        vec3 ambient = torch.ambient * vec3(texture(material.diffuse, TexCoord));
-        
-        // diffuse 
-        vec3 norm = normalize(Normal);
-        float diff = max(dot(norm, torchDir), 0.0);
-        vec3 diffuse = torch.diffuse * diff * vec3(texture(material.diffuse, TexCoord));  
-        
-        // specular
-        vec3 viewDir = normalize(viewPos - FragPos);
-        vec3 reflectDir = reflect(-torchDir, norm);  
-        float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-        vec3 specular = torch.specular * spec * vec3(texture(material.specular, TexCoord));  
-        
-        // attenuation
-        //float distance    = length(torch.position - FragPos);
-        //float attenuation = 1.0 / (lamp.constant + lamp.linear * distance + lamp.quadratic * (distance * distance));    
-        //diffuse *= attenuation;
-        //specular *= attenuation;   
+    // ambient
+    vec3 ambient = light.ambient * vec3(texture(material.diffuse, TexCoord));
 
-        diffuse *= intensity;
-        specular *= intensity;   
-            
-        vec3 result = ambient + diffuse + specular;
-        FragColor = vec4(result, 1.0);
-    }
-    else 
-    {
-        FragColor = vec4(torch.ambient * vec3(texture(material.diffuse, TexCoord)), 1.0);
-    }
+    // diffuse 
+    vec3 norm = normalize(Normal);
+    vec3 lightDir = normalize(light.position - FragPos);
+    float diff = max(dot(norm, lightDir), 0.0);
+    vec3 diffuse = light.diffuse * diff * vec3(texture(material.diffuse, TexCoord));  
 
+    // specular
+    vec3 viewDir = normalize(viewPos - FragPos);
+    vec3 reflectDir = reflect(-lightDir, norm);  
+    float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
+    vec3 specular = light.specular * spec * vec3(texture(material.specular, TexCoord));  
+    
+    // soft spotlight
+    float theta = dot(lightDir, normalize(-light.direction));
+    float epsilon = light.cutOff - light.outerCutOff;
+    float intensity = clamp((theta - light.outerCutOff) / epsilon, 0.0, 1.0);
+    diffuse *= intensity;
+    specular *= intensity;   
 
-
-    //// --- ambient --- 
-    //vec3 ambient          = sun.ambient * vec3(texture(material.diffuse, TexCoord));
-  	//
-    //// --- diffuse ---
-    //vec3 norm             = normalize(Normal);
-    //vec3 lightDir         = normalize(-sun.direction); // NOTE: Negative b/c it's easier to imagine the light coming FROM the light source
-    //float diff            = max(dot(norm, lightDir), 0.0);
-    //vec3 diffuse          = sun.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
-
-    //// --- specular ---
-    //vec3 viewDir          = normalize(viewPos - FragPos);
-    //vec3 reflectDir       = reflect(-lightDir, norm);
-    //float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    //vec3 specular         = sun.specular * spec * vec3(texture(material.specular, TexCoord));
-
-
-
-
-
-    //// --- attenuation ---
-    //float distance        = length(lamp.position - FragPos);
-    //float attenuation     = 1.0 / (lamp.constant + lamp.linear * distance + lamp.quadratic * (distance * distance));
-
-    //// --- ambient --- 
-    //vec3 ambient          = lamp.ambient * vec3(texture(material.diffuse, TexCoord));
-  	//
-    //// --- diffuse ---
-    //vec3 norm             = normalize(Normal);
-    //vec3 lightDir         = normalize(lamp.position - FragPos);
-    //float diff            = max(dot(norm, lightDir), 0.0);
-    //vec3 diffuse          = lamp.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
-
-    //// --- specular ---
-    //vec3 viewDir          = normalize(viewPos - FragPos);
-    //vec3 reflectDir       = reflect(-lightDir, norm);
-    //float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    //vec3 specular         = lamp.specular * spec * vec3(texture(material.specular, TexCoord));
-
-    //// --- apply ---
-    //ambient     *= attenuation;
-    //diffuse     *= attenuation;
-    //specular    *= attenuation;
-    //FragColor = vec4((ambient + diffuse + specular), 1.0);
+    // attenuation
+    float distance    = length(light.position - FragPos);
+    float attenuation = 1.0 / (light.constant + light.linear * distance + light.quadratic * (distance * distance));    
+    diffuse *= attenuation;
+    specular *= attenuation;   
+    
+    vec3 result = ambient + diffuse + specular;
+    FragColor = vec4(result, 1.0);
 } 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -7,12 +7,22 @@ struct Material {
     float shininess;
 };
 
-struct Light {
-    //vec3 position;
+struct DirectionalLight {
     vec3 direction;
     vec3 ambient;
     vec3 diffuse;
     vec3 specular;
+};
+
+struct PointLight {
+    vec3 position;
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+
+    float constant;
+    float linear;
+    float quadratic;
 };
 
 in vec3 FragPos;
@@ -22,25 +32,53 @@ in vec2 TexCoord;
 uniform vec3 viewPos;
 
 uniform Material material;
-uniform Light light;
+uniform DirectionalLight sun;
+uniform PointLight torch;
 
 void main()
 {
+    //// --- ambient --- 
+    //vec3 ambient          = sun.ambient * vec3(texture(material.diffuse, TexCoord));
+  	//
+    //// --- diffuse ---
+    //vec3 norm             = normalize(Normal);
+    //vec3 lightDir         = normalize(-sun.direction); // NOTE: Negative b/c it's easier to imagine the light coming FROM the light source
+    //float diff            = max(dot(norm, lightDir), 0.0);
+    //vec3 diffuse          = sun.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
+
+    //// --- specular ---
+    //vec3 viewDir          = normalize(viewPos - FragPos);
+    //vec3 reflectDir       = reflect(-lightDir, norm);
+    //float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
+    //vec3 specular         = sun.specular * spec * vec3(texture(material.specular, TexCoord));
+
+
+
+
+
+    // attenuation
+    float distance        = length(torch.position - FragPos);
+    float attenuation     = 1.0 / (torch.constant + torch.linear * distance + 
+                                    torch.quadratic * (distance * distance));
+
     // --- ambient --- 
-    vec3 ambient          = light.ambient * vec3(texture(material.diffuse, TexCoord));
+    vec3 ambient          = torch.ambient * vec3(texture(material.diffuse, TexCoord));
   	
     // --- diffuse ---
     vec3 norm             = normalize(Normal);
-    vec3 lightDir         = normalize(-light.direction); // NOTE: Negative b/c it's easier to imagine the light coming FROM the light source
+    vec3 lightDir         = normalize(torch.position - FragPos);
     float diff            = max(dot(norm, lightDir), 0.0);
-    vec3 diffuse          = light.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
+    vec3 diffuse          = torch.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
 
     // --- specular ---
     vec3 viewDir          = normalize(viewPos - FragPos);
     vec3 reflectDir       = reflect(-lightDir, norm);
     float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    vec3 specular         = light.specular * spec * vec3(texture(material.specular, TexCoord));
+    vec3 specular         = torch.specular * spec * vec3(texture(material.specular, TexCoord));
 
     // --- apply ---
+    ambient *= attenuation;
+    diffuse *= attenuation;
+    specular *= attenuation;
     FragColor = vec4((ambient + diffuse + specular), 1.0);
 } 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -36,7 +36,6 @@ struct SpotLight {
     vec3 position;
     vec3 direction;
 
-    vec3 ambient;
     vec3 diffuse;
     vec3 specular;
 
@@ -137,9 +136,6 @@ vec3 CalcPointLight(PointLight light, vec3 normal, vec3 viewDir) {
 }
 
 vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 viewDir) {
-    // ambient
-    vec3 ambient = light.ambient * vec3(texture(material.diffuse, TexCoord));
-
     // diffuse
     vec3 lightDir = normalize(light.position - FragPos);
     vec3 diffuse = light.diffuse * max(dot(normal, lightDir), 0.0) * vec3(texture(material.diffuse, TexCoord));
@@ -162,9 +158,8 @@ vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 viewDir) {
                                (light.linear * distance) + 
                                (light.quadratic * distance * distance));
 
-    ambient *= attenuation;
     diffuse *= attenuation;
     specular *= attenuation;
 
-    return (ambient + diffuse + specular);
+    return (diffuse + specular);
 }

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -62,6 +62,7 @@ uniform Material material;
 uniform DirectionalLight dirLight;
 uniform PointLight pointLights[NR_POINT_LIGHTS];
 uniform SpotLight flashLight; // attached to the player
+uniform bool flashLightOn = false;
 
 // ----- FRAGMENT SHADER MAIN ----- 
 void main() {
@@ -78,7 +79,9 @@ void main() {
     }
 
     // TODO: phase 3: spot lights
-    result += CalcSpotLight(flashLight, normal, viewDir);
+    if (flashLightOn) {
+        result += CalcSpotLight(flashLight, normal, viewDir);
+    }
 
     FragColor = vec4(result, 1.0);
 } 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -25,6 +25,16 @@ struct PointLight {
     float quadratic;
 };
 
+struct FlashLight {
+    vec3 position; 
+    vec3 direction; 
+    float cutOff;
+
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+};
+
 in vec3 FragPos;
 in vec3 Normal;
 in vec2 TexCoord;
@@ -34,9 +44,46 @@ uniform vec3 viewPos;
 uniform Material material;
 uniform DirectionalLight sun;
 uniform PointLight lamp;
+uniform FlashLight torch;
 
 void main()
 {
+    vec3 torchDir = normalize(torch.position - FragPos);
+    float theta = dot(torchDir, normalize(-torch.direction));
+
+    if (theta > torch.cutOff)
+    {    
+        // ambient
+        vec3 ambient = torch.ambient * vec3(texture(material.diffuse, TexCoord));
+        
+        // diffuse 
+        vec3 norm = normalize(Normal);
+        float diff = max(dot(norm, torchDir), 0.0);
+        vec3 diffuse = torch.diffuse * diff * vec3(texture(material.diffuse, TexCoord));  
+        
+        // specular
+        vec3 viewDir = normalize(viewPos - FragPos);
+        vec3 reflectDir = reflect(-torchDir, norm);  
+        float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
+        vec3 specular = torch.specular * spec * vec3(texture(material.specular, TexCoord));  
+        
+        // attenuation
+        float distance    = length(torch.position - FragPos);
+        float attenuation = 1.0 / (lamp.constant + lamp.linear * distance + lamp.quadratic * (distance * distance));    
+
+        diffuse *= attenuation;
+        specular *= attenuation;   
+            
+        vec3 result = ambient + diffuse + specular;
+        FragColor = vec4(result, 1.0);
+    }
+    else 
+    {
+        FragColor = vec4(torch.ambient * vec3(texture(material.diffuse, TexCoord)), 1.0);
+    }
+
+
+
     //// --- ambient --- 
     //vec3 ambient          = sun.ambient * vec3(texture(material.diffuse, TexCoord));
   	//
@@ -56,29 +103,28 @@ void main()
 
 
 
-    // attenuation
-    float distance        = length(lamp.position - FragPos);
-    float attenuation     = 1.0 / (lamp.constant + lamp.linear * distance + 
-                                    lamp.quadratic * (distance * distance));
+    //// --- attenuation ---
+    //float distance        = length(lamp.position - FragPos);
+    //float attenuation     = 1.0 / (lamp.constant + lamp.linear * distance + lamp.quadratic * (distance * distance));
 
-    // --- ambient --- 
-    vec3 ambient          = lamp.ambient * vec3(texture(material.diffuse, TexCoord));
-  	
-    // --- diffuse ---
-    vec3 norm             = normalize(Normal);
-    vec3 lightDir         = normalize(lamp.position - FragPos);
-    float diff            = max(dot(norm, lightDir), 0.0);
-    vec3 diffuse          = lamp.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
+    //// --- ambient --- 
+    //vec3 ambient          = lamp.ambient * vec3(texture(material.diffuse, TexCoord));
+  	//
+    //// --- diffuse ---
+    //vec3 norm             = normalize(Normal);
+    //vec3 lightDir         = normalize(lamp.position - FragPos);
+    //float diff            = max(dot(norm, lightDir), 0.0);
+    //vec3 diffuse          = lamp.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
 
-    // --- specular ---
-    vec3 viewDir          = normalize(viewPos - FragPos);
-    vec3 reflectDir       = reflect(-lightDir, norm);
-    float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    vec3 specular         = lamp.specular * spec * vec3(texture(material.specular, TexCoord));
+    //// --- specular ---
+    //vec3 viewDir          = normalize(viewPos - FragPos);
+    //vec3 reflectDir       = reflect(-lightDir, norm);
+    //float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
+    //vec3 specular         = lamp.specular * spec * vec3(texture(material.specular, TexCoord));
 
-    // --- apply ---
-    ambient *= attenuation;
-    diffuse *= attenuation;
-    specular *= attenuation;
-    FragColor = vec4((ambient + diffuse + specular), 1.0);
+    //// --- apply ---
+    //ambient     *= attenuation;
+    //diffuse     *= attenuation;
+    //specular    *= attenuation;
+    //FragColor = vec4((ambient + diffuse + specular), 1.0);
 } 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -61,10 +61,6 @@ uniform Material material;
 // Lighting
 uniform DirectionalLight dirLight;
 uniform PointLight pointLights[NR_POINT_LIGHTS];
-
-// TODO: Write up a function to calculate the SpotLight.
-// In this case, I want to create a flashlight, so it'll be attached to 
-//  the player... GOODLUCK!
 uniform SpotLight flashLight; // attached to the player
 
 // ----- FRAGMENT SHADER MAIN ----- 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -1,0 +1,45 @@
+#version 330 core
+out vec4 FragColor;
+
+struct Material {
+    sampler2D diffuse;
+    sampler2D specular;
+    float shininess;
+};
+
+struct Light {
+    vec3 position;
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+};
+
+in vec3 FragPos;
+in vec3 Normal;
+in vec2 TexCoord;
+  
+uniform vec3 viewPos;
+
+uniform Material material;
+uniform Light light;
+
+void main()
+{
+    // --- ambient --- 
+    vec3 ambient          = light.ambient * vec3(texture(material.diffuse, TexCoord));
+  	
+    // --- diffuse ---
+    vec3 norm             = normalize(Normal);
+    vec3 lightDir         = normalize(light.position - FragPos);
+    float diff            = max(dot(norm, lightDir), 0.0);
+    vec3 diffuse          = light.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
+
+    // --- specular ---
+    vec3 viewDir          = normalize(viewPos - FragPos);
+    vec3 reflectDir       = reflect(-lightDir, norm);
+    float spec            = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
+    vec3 specular         = light.specular * spec * vec3(texture(material.specular, TexCoord));
+
+    // --- apply ---
+    FragColor = vec4((ambient + diffuse + specular), 1.0);
+} 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -69,17 +69,16 @@ void main() {
     vec3 normal = normalize(Normal);
     vec3 viewDir = normalize(viewPos - FragPos);
 
-    //// phase 1: direction light 
-    //vec3 result = CalcDirLight(dirLight, normal, viewDir);
+    // phase 1: direction light 
+    vec3 result = CalcDirLight(dirLight, normal, viewDir);
 
-    //// phase 2: point lights
-    //for (int plIdx = 0; plIdx < NR_POINT_LIGHTS; ++plIdx) {
-    //    result += CalcPointLight(pointLights[plIdx], normal, viewDir);
-    //}
+    // phase 2: point lights
+    for (int plIdx = 0; plIdx < NR_POINT_LIGHTS; ++plIdx) {
+        result += CalcPointLight(pointLights[plIdx], normal, viewDir);
+    }
 
     // TODO: phase 3: spot lights
-    //result += CalcSpotLight(flashLight, normal, viewDir);
-    vec3 result = CalcSpotLight(flashLight, normal, viewDir);
+    result += CalcSpotLight(flashLight, normal, viewDir);
 
     FragColor = vec4(result, 1.0);
 } 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -8,6 +8,7 @@ in vec2 TexCoord;
 
 // Declarations
 vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir);
+vec3 CalcPointLight(PointLight light, vec3 normal, vec3 viewDir);
  
 // Structs
 struct Material {
@@ -23,6 +24,16 @@ struct DirectionalLight {
     vec3 specular;
 }
 
+struct PointLight {
+    vec3 position;
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+    float constant;
+    float linear;
+    float quadratic;
+}
+
 // View position
 uniform vec3 viewPos;
 
@@ -31,6 +42,7 @@ uniform Material material;
 
 // Lighting
 uniform DirectionalLight dirLight;
+uniform PointLight pointLight;
 
 // ----- FRAGMENT SHADER MAIN ----- 
 void main() {
@@ -52,6 +64,34 @@ vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir) {
     vec3 spec = pow(max(dot(reflectDir, viewDir),0.0), material.shininess);
     vec3 specular = light.specular * spec * 
                         vec3(texture(material.specular, TexCoord));
+
+    return (ambient + diffuse + specular);
+}
+
+vec3 CalcPointLight(PointLight light, vec3 normal, vec3 viewDir) {
+    // ambient 
+    vec3 ambient = light.ambient * vec3(texture(material.ambient, TexCoord));
+
+    // diffuse 
+    vec3 lightDir = normalize(light.position - FragPos);
+    vec3 diffuse = light.diffuse * max(dot(normal, lightDir), 0.0) * 
+                        vec3(texture(material.diffuse, TexCoord));
+
+    // specular 
+    vec3 reflectDir = reflect(-lightDir, normal);
+    vec3 spec = pow(max(dot(reflectDir, viewDir),0.0), material.shininess);
+    vec3 specular = light.specular * spec * 
+                        vec3(texture(material.specular, TexCoord));
+
+    // attenuation (light intensity based off distance)
+    float distance = length(light.position, FragPos);
+    float attenuation = 1.0 / ((light.constant) +
+                               (light.linear * distance) +
+                               (light.quadratic * distance * distance));
+
+    ambient *= attenuation;
+    diffuse *= attenuation;
+    specular *= attenuation;
 
     return (ambient + diffuse + specular);
 }

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -31,7 +31,7 @@ void main()
   	
     // --- diffuse ---
     vec3 norm             = normalize(Normal);
-    vec3 lightDir         = normalize(-light.direction);
+    vec3 lightDir         = normalize(-light.direction); // NOTE: Negative b/c it's easier to imagine the light coming FROM the light source
     float diff            = max(dot(norm, lightDir), 0.0);
     vec3 diffuse          = light.diffuse * diff * vec3(texture(material.diffuse, TexCoord));
 

--- a/src/2.lighting/16.light_casters/object.frag
+++ b/src/2.lighting/16.light_casters/object.frag
@@ -1,68 +1,57 @@
 #version 330 core
 out vec4 FragColor;
 
+// Input from vertex shader
+in vec3 FragPos;
+in vec3 Normal;
+in vec2 TexCoord;
+
+// Declarations
+vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir);
+ 
+// Structs
 struct Material {
     sampler2D diffuse;
     sampler2D specular;
     float shininess;
 };
 
-struct Light {
-    vec3 position; 
-    vec3 direction; 
-
-    float cutOff;
-    float outerCutOff;
-
+struct DirectionalLight {
+    vec3 direction;
     vec3 ambient;
     vec3 diffuse;
     vec3 specular;
+}
 
-    float constant;
-    float linear;
-    float quadratic;
-};
-
-in vec3 FragPos;
-in vec3 Normal;
-in vec2 TexCoord;
-  
+// View position
 uniform vec3 viewPos;
 
+// Material
 uniform Material material;
-uniform Light light;
 
-void main()
-{
+// Lighting
+uniform DirectionalLight dirLight;
 
-    // ambient
-    vec3 ambient = light.ambient * vec3(texture(material.diffuse, TexCoord));
+// ----- FRAGMENT SHADER MAIN ----- 
+void main() {
+
+} 
+
+// Function Definitions
+vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir) {
+    // ambient 
+    vec3 ambient = light.ambient * vec3(texture(material.ambient, TexCoord));
 
     // diffuse 
-    vec3 norm = normalize(Normal);
-    vec3 lightDir = normalize(light.position - FragPos);
-    float diff = max(dot(norm, lightDir), 0.0);
-    vec3 diffuse = light.diffuse * diff * vec3(texture(material.diffuse, TexCoord));  
+    vec3 lightDir = normalize(-light.direction);
+    vec3 diffuse = light.diffuse * max(dot(normal, lightDir), 0.0) * 
+                        vec3(texture(material.diffuse, TexCoord));
 
-    // specular
-    vec3 viewDir = normalize(viewPos - FragPos);
-    vec3 reflectDir = reflect(-lightDir, norm);  
-    float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    vec3 specular = light.specular * spec * vec3(texture(material.specular, TexCoord));  
-    
-    // soft spotlight
-    float theta = dot(lightDir, normalize(-light.direction));
-    float epsilon = light.cutOff - light.outerCutOff;
-    float intensity = clamp((theta - light.outerCutOff) / epsilon, 0.0, 1.0);
-    diffuse *= intensity;
-    specular *= intensity;   
+    // specular 
+    vec3 reflectDir = reflect(-lightDir, normal);
+    vec3 spec = pow(max(dot(reflectDir, viewDir),0.0), material.shininess);
+    vec3 specular = light.specular * spec * 
+                        vec3(texture(material.specular, TexCoord));
 
-    // attenuation
-    float distance    = length(light.position - FragPos);
-    float attenuation = 1.0 / (light.constant + light.linear * distance + light.quadratic * (distance * distance));    
-    diffuse *= attenuation;
-    specular *= attenuation;   
-    
-    vec3 result = ambient + diffuse + specular;
-    FragColor = vec4(result, 1.0);
-} 
+    return (ambient + diffuse + specular);
+}

--- a/src/2.lighting/16.light_casters/object.vert
+++ b/src/2.lighting/16.light_casters/object.vert
@@ -1,0 +1,21 @@
+#version 330 core
+layout (location = 0) in vec3 inFragPos;
+layout (location = 1) in vec3 inNormal;
+layout (location = 2) in vec2 inTexCoord;
+
+out vec3 FragPos;
+out vec3 Normal;
+out vec2 TexCoord;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main()
+{
+    FragPos     = vec3(model * vec4(inFragPos, 1.0));
+    Normal      = mat3(transpose(inverse(model))) * inNormal;
+    TexCoord    = inTexCoord;
+
+    gl_Position = projection * view * vec4(FragPos, 1.0);
+}


### PR DESCRIPTION
Added three types of lighting:
- Directional
- Spot (flashlight)
- Point

Wrote functions to automatically handle lighting calculations, so the rendering engine can now support multiple kinds of light-types at the same time.

Note: only 9 point lights can be added to a scene at a time. The reason for this lies within the way this formatted string is handled "pointLights[%d]", which does not support any integers greater than 9. I'm most likely not going to fix this because it's not really a big deal.